### PR TITLE
Enable for dependancies found multiple times

### DIFF
--- a/lib/code-class.js
+++ b/lib/code-class.js
@@ -70,11 +70,13 @@ function CodeInfo(input, skip_cache_and_pipeline){
         var already_retrieving = false;
         return function(callback){
             if( already_retrieving ) {
-                throw new Error([
-                    "No support for multiple parallel retrieve_dependencies() calls.",
-                    "Yet a second parallel call is being executed on "+code.id+".",
-                    "Run the second call sequentially instead."
-                ].join(' '));
+                // callback(code);
+                return code;
+                // throw new Error([
+                //     "No support for multiple parallel retrieve_dependencies() calls.",
+                //     "Yet a second parallel call is being executed on "+code.id+".",
+                //     "Run the second call sequentially instead."
+                // ].join(' '));
             }
             already_retrieving = true;
             return (

--- a/lib/code-class.js
+++ b/lib/code-class.js
@@ -83,7 +83,7 @@ function CodeInfo(input, skip_cache_and_pipeline){
                 that
                 ._execute_pipeline({start: break_})
                 .then(function(){
-                    already_retrieving = false;
+                    // already_retrieving = false;
                     if( callback ) {
                         // stop Promise from catching errors
                         setTimeout(function(){


### PR DESCRIPTION
Fix bug #2 : 
- The parser simply bail out if one is already parsing the file
- If the file has been parsed once, no need to parse it again
